### PR TITLE
Fix typos in schema, link to correct schema, instruct user about backup dir

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ The basics
 	$GLOBALS['cfg']['instagram_oauth_callback'] = 'auth/';
 
 	# You will need to setup a MySQL database and plug in the specifics
-	# here: https://github.com/straup/privatesquare/blob/master/schema
+	# here: https://github.com/straup/parallel-ogram/tree/master/schema
 
 	# See also: https://github.com/straup/flamework-tools/blob/master/bin/setup-db.sh
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,6 +56,11 @@ The basics
 
 	$GLOBALS['cfg']['enable_feature_backups'] = 1;
 	$GLOBALS['cfg']['enable_feature_backups_registration'] = 1;
+	
+	# This is where your Instagram photos will be stored
+	# It should have a trailing slash e.g. /usr/local/parallelogram-static/
+	
+	$GLOBALS['cfg']['instagram_static_path'] = ''
 
 Limiting access (invite codes and "god" auth)
 ===

--- a/schema/db_main.schema
+++ b/schema/db_main.schema
@@ -12,8 +12,7 @@ CREATE TABLE `users` (
   `cluster_id` tinyint(3) unsigned NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `by_email` (`email`),
-  UNIQUE KEY `by_username` (`username`,`deleted`),
-  KEY `backup_users` (`backup_photos`)
+  UNIQUE KEY `by_username` (`username`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `users_password_reset`;

--- a/schema/db_users.schema
+++ b/schema/db_users.schema
@@ -29,6 +29,6 @@ CREATE TABLE `InstagramLikes` (
   `created` INT(11) UNSIGNED NOT NULL,
   UNIQUE KEY `by_like` (`user_id`, `photo_id`),
   KEY `by_user` (`user_id`, `created`),
-  KEY `by_owner` (`user_id`, `owner_id`, `created`)
+  KEY `by_owner` (`user_id`, `owner_id`, `created`),
   KEY `filter` (`user_id`, `filter`, `created`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;

--- a/www/include/config.php.example
+++ b/www/include/config.php.example
@@ -13,6 +13,17 @@
 
 	# Things you'll need to tweak
 
+	# You will need valid Instagram OAuth credentials
+	# See also: http://instagram.com/developer/client/register/
+
+	$GLOBALS['cfg']['instagram_oauth_key'] = '';
+	$GLOBALS['cfg']['instagram_oauth_secret'] = '';
+	
+	# Don't change this (but if you do be sure to update the main
+	# .htaccess file accordingly).
+	
+	$GLOBALS['cfg']['instagram_oauth_callback'] = 'auth/';
+
 	# Setting up the database
 	# See also: https://github.com/straup/flamework-tools/blob/master/bin/setup-db.sh
 
@@ -41,6 +52,11 @@
 
 	$GLOBALS['cfg']['enable_feature_backups'] = 1;
 	$GLOBALS['cfg']['enable_feature_backups_registration'] = 1;
+
+	# This is where your Instagram photos will be stored
+	# It should have a trailing slash e.g. /usr/local/parallelogram-static/
+	
+	$GLOBALS['cfg']['instagram_static_path'] = ''
 
 	# Invite codes – these are used to limit who can register
 	# to have their photos backed up. You'll need to do a


### PR DESCRIPTION
Current schema won't import into mySQL without these patches

Also, I added some instructions about how to specify where the Instagram photos will be stored and copied the config flags from INSTALL.md to the config.php.example
