### PR TITLE
Fixes pagination on 'likes' page

### DIFF
--- a/www/instagram_likes_user.php
+++ b/www/instagram_likes_user.php
@@ -53,9 +53,11 @@
 
 	$rsp = instagram_likes_for_user($owner, $more);
 
+	$pagination_url = instagram_urls_for_user_likes($owner);
+
 	$GLOBALS['smarty']->assign_by_ref("photos", $rsp['rows']);
 	$GLOBALS['smarty']->assign_by_ref("owner", $owner);
-
+	$GLOBALS['smarty']->assign("pagination_url", $pagination_url);
 	$GLOBALS['smarty']->display("page_instagram_likes_user.txt");
 	exit();
 ?>


### PR DESCRIPTION
The pagination_url wasn't getting set and thus pagination was broken when the '/likes' first page didn't end with a trailing slash.
