### PR TITLE
Fix photo secret since Instagram changed it

### DIFF
--- a/www/include/lib_instagram_photos_import.php
+++ b/www/include/lib_instagram_photos_import.php
@@ -97,7 +97,7 @@
 		# (20120321/straup)
 
 		$photo_base = basename($photo_url);
-		$photo_secret = preg_replace("/_\d+.jpg/", "", $photo_base);
+		$photo_secret = preg_replace("/_\d+\.jpg/", "", $photo_base);
 
 		$id = $row['id'];
 		list($photo_id, $ignore) = explode("_", $id, 2);

--- a/www/include/lib_instagram_photos_import.php
+++ b/www/include/lib_instagram_photos_import.php
@@ -97,7 +97,7 @@
 		# (20120321/straup)
 
 		$photo_base = basename($photo_url);
-		$photo_secret = str_replace("_7.jpg", "", $photo_base);
+		$photo_secret = preg_replace("/_\d+.jpg/", "", $photo_base);
 
 		$id = $row['id'];
 		list($photo_id, $ignore) = explode("_", $id, 2);


### PR DESCRIPTION
It appears that Instagram is now on '_8.jpg'. I've future-proofed this changing by just looking for some number of digits (assuming they keep with this pattern).

I'm also assuming that the ID before the signature is unique even across so those version numbers. That's a big assumption, I know.

I also had to re-run my backup. I just hacked the backup_photos.php script to change min_timestamp to 0. If you have a lot of photos, picking a more reasonable start date (aka, whenever it broke...) is more advisable.
