### PR TITLE
instagram appear to have changed photo secret again

### DIFF
--- a/www/include/lib_instagram_photos_import.php
+++ b/www/include/lib_instagram_photos_import.php
@@ -97,7 +97,7 @@
 		# (20120321/straup)
 
 		$photo_base = basename($photo_url);
-		$photo_secret = preg_replace("/_\d+\.jpg/", "", $photo_base);
+		$photo_secret = preg_replace("/_\d+(?:_n)?\.jpg/", "", $photo_base);
 
 		$id = $row['id'];
 		list($photo_id, $ignore) = explode("_", $id, 2);


### PR DESCRIPTION
more recent photos have a _n on the end, old ones helpfully don't so
make sure it's optional.
